### PR TITLE
fix: Handling of Unauthorized Requests

### DIFF
--- a/chegg.py
+++ b/chegg.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import requests
 import yaml
 
@@ -7,12 +8,12 @@ from notifications import TelegramBot
 from utils import log
 
 config = ''
-with open("config.yaml", "r") as yamlfile:
+with open("config.yaml", "r", encoding="utf-8") as yamlfile:
     config = yaml.load(yamlfile, Loader=yaml.FullLoader)
 
 class Chegg:
     """
-    A class that automates the process of answering ques on chegg and skip the question which are not good to answer.
+    A class that automates the process of answering questions on chegg and skips the questions which are not good to answer.
     """
     URL = "https://gateway.chegg.com/nestor-graph/graphql"
     DASHBOARD_URL = "https://expert.chegg.com/qna/authoring/answer"
@@ -36,7 +37,7 @@ class Chegg:
         "operationName": "NextQuestionAnsweringAssignment",
         "variables": {},
         "query": "query NextQuestionAnsweringAssignment {\n  nextQuestionAnsweringAssignment {\n    question {\n      body\n      id\n      uuid\n      subject {\n        id\n        name\n        subjectGroup {\n          id\n          name\n          __typename\n        }\n        __typename\n      }\n      imageTranscriptionText\n      lastAnswerUuid\n      __typename\n    }\n    langTranslation {\n      body\n      translationLanguage\n      __typename\n    }\n    questionGeoLocation {\n      countryCode\n      countryName\n      languages\n      __typename\n    }\n    questionRoutingDetails {\n      answeringStartTime\n      bonusCount\n      bonusTimeAllocationEnabled\n      checkAnswerStructureEnabled\n      hasAnsweringStarted\n      questionAssignTime\n      questionSolvingProbability\n      routingType\n      allocationExperimentId\n      questionQualityFactor\n      __typename\n    }\n    __typename\n  }\n}"
-})
+    })
     SKIP_PAYLOAD = {
         "operationName": "SkipQuestionAssignment",
         "variables": {
@@ -50,13 +51,12 @@ class Chegg:
     }
     TIMEOUT_FOR_REQUESTS = (10, 20)
 
-    def __init__(self, headers={}, keywords=[], parse_images=False):
+    def __init__(self, headers=None, keywords=None, parse_images=False):
         self.question = None
         self.question_id = None
         self.question_body = None
-        self.keywords = keywords
+        self.keywords = keywords or []
         self.headers = Chegg.get_headers(headers)
-        self.keywords = keywords
         self.parse_images = parse_images
         self.notify = TelegramBot()
         self.question_uuid = None
@@ -65,33 +65,36 @@ class Chegg:
     @staticmethod
     def get_headers(headers):
         '''
-            Add fields to headers
+        Add fields to headers
         '''
         global_headers = Chegg.HEADERS
         global_headers.update(headers)
         return global_headers
 
     def create_skip_payload(self):
-        log(f'Creating skip payload for {self.question_id}')
+        """
+        Create the skip payload for the current question.
+        """
+        log('Creating skip payload for {}'.format(self.question_id))
         payload = Chegg.SKIP_PAYLOAD
         payload["variables"]["questionId"] = self.question_id
         return json.dumps(payload)
 
     def fetch_question(self):
         '''
-            # Fetch the lastest question in the queue
-            # Returns dict with question_id, body etc if ques is present
-            # else returns None
-            # or Raise Exception
+        Fetch the latest question in the queue.
+        Returns dict with question_id, body, etc. if question is present.
+        Otherwise, returns None or raises an Exception.
         '''
-        log(f'Fetching the ques')
+        log('Fetching the question')
         response = requests.request(
             "POST", Chegg.URL, headers=self.headers, data=Chegg.FETCH_PAYLOAD, timeout=Chegg.TIMEOUT_FOR_REQUESTS)
-        if response.status_code == 401:
-            log("Unauthorised!! Cookie expired. Please give a new cookie.")
-            exit()
         res_data = json.loads(response.text)
-        log(f'HTTP Response {response.status_code}')
+        if res_data.get('errors') is not None:
+            log(res_data['errors'][0]['message'])
+            log("Note: If you are getting unauthorized error then please give a new cookie.")
+            sys.exit()
+        log('HTTP Response {}'.format(response.status_code))
         ques_obj = res_data['data']['nextQuestionAnsweringAssignment']['question'] if res_data['data'] is not None else None
         if ques_obj:
             self.question = ques_obj
@@ -104,20 +107,23 @@ class Chegg:
 
     def skip_question(self):
         '''
-        Skip the question with current question_id
+        Skip the question with the current question_id.
         '''
-        log(f'Skipping the question')
+        log('Skipping the question')
         payload = self.create_skip_payload()
-        res = requests.request(
+        requests.request(
             "POST", Chegg.URL, headers=Chegg.HEADERS, data=payload, timeout=Chegg.TIMEOUT_FOR_REQUESTS)
 
     def answer_question(self):
-        log(f"Hurray!! You got a suitable question to answer -> {Chegg.DASHBOARD_URL} ")
+        """
+        Answer the current question.
+        """
+        log("Hurray!! You got a suitable question to answer -> {}".format(Chegg.DASHBOARD_URL))
         # Play the alert sound on terminal
-        os.system(f"afplay {config.get('notification_sound_path')}")
+        os.system("afplay {}".format(config.get('notification_sound_path')))
         message = "Hurray!! You got a suitable question to answer " + self.question_body
-        self.notify.send_notificaion(
+        self.notify.send_notification(
             repr(message))
 
-    def __repr__(self) -> str:
-        return self.__dict__
+    def __repr__(self):
+        return str(self.__dict__)


### PR DESCRIPTION
fixes: #18 
## Description
The Chegg API response code for unauthorized requests has recently changed from 401 to 200, accompanied by errors in the response body. This modification has caused our Chegg Python script to provide inaccurate results. Instead of signaling an unauthorized error, it incorrectly indicates that there are no more questions left in the queue.

## Changes Made
In this pull request, I have addressed this issue by updating the script to accurately handle the new Chegg API response structure. It now correctly identifies unauthorized requests and displays the appropriate error message, ensuring the script functions as intended.

## Testing
I thoroughly tested the changes by:

1. Simulating an unauthorized request and confirming the script correctly identifies it.
2. Checking for unintended side effects on other functionalities.
3. Verifying that the script still works as expected for authorized requests.
